### PR TITLE
Consul checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN ln -sf /var/lib/rabbitmq/.erlang.cookie /root/
 RUN ln -sf /usr/lib/rabbitmq/lib/rabbitmq_server-$RABBITMQ_VERSION/plugins /plugins
 
 # Add envconsul
-ENV ENVCONSUL_VERSION=0.6.1
+ENV ENVCONSUL_VERSION=0.6.2
 ENV CONSUL_HTTP_ADDR=localhost:8500
 
 RUN apt-get update && \

--- a/consul-env.sh
+++ b/consul-env.sh
@@ -1,11 +1,43 @@
 #!/bin/bash
 
 if [ ! -z "$CONSUL_PREFIX" ]; then
+  echo -e "Checking for Consul service"
+  until $(curl --output /dev/null --silent --head --fail http://${CONSUL_HTTP_ADDR}/v1/agent/self); do
+    printf '.'
+    sleep 1
+  done
+
   if [ ! -z "$CONSUL_SERVICE" ]; then
+    echo -e "Checking service '${CONSUL_SERVICE}' for members"
+    until [ "$(echo $(curl -s http://${CONSUL_HTTP_ADDR}/v1/health/service/${CONSUL_SERVICE}) | jq '. | length')" -gt 0 ]; do
+      printf '.'
+      sleep 1
+    done
+
+    export CONSUL_SESSION="$(echo $(curl -s -X PUT -d "{\"Name\":\"${HOSTNAME}\",\"ttl\":\"300s\",\"behavior\":\"delete\"}" http://${CONSUL_HTTP_ADDR}/v1/session/create) | jq -r .ID)"
+
+    echo 'Waiting for healthy nodes'
+    until [ "$(echo $(curl -s http://${CONSUL_HTTP_ADDR}/v1/health/service/${CONSUL_SERVICE}?passing) | jq '. | length')" -gt 0 ]; do
+
+      if $(curl -s -X PUT http://${CONSUL_HTTP_ADDR}/v1/kv/service/${CONSUL_SERVICE}/leader?acquire=${CONSUL_SESSION}); then
+        export CLUSTER_SEED=true
+        echo 'This node is the first in the cluster'
+        break
+      fi
+
+      printf '.'
+      sleep 1
+    done
+
+    if [ ! "${CLUSTER_SEED}" ]; then
+      curl -s http://${CONSUL_HTTP_ADDR}/v1/session/destroy/${CONSUL_SESSION}
+      export RABBITMQ_CLUSTER_NODES="rabbit@$(echo $(curl -s http://${CONSUL_HTTP_ADDR}/v1/health/service/${CONSUL_SERVICE}?passing) | jq -r .[0].Node.Node).node.consul"
+      echo -e "Setting cluster node: ${RABBITMQ_CLUSTER_NODES}"
+    fi
+
     export RABBITMQ_USE_LONGNAME=true
     export RABBITMQ_NODENAME="rabbit@${HOSTNAME}.node.consul"
-    export RABBITMQ_CLUSTER_NODES="rabbit@`echo $(curl -s http://${CONSUL_HTTP_ADDR}/v1/health/service/${CONSUL_SERVICE}?passing) | jq -r .[0].Node.Node`.node.consul"
-    echo -e "Setting RabbitMQ cluster nodes: ${RABBITMQ_CLUSTER_NODES}"
+    
   fi
   if [ ! -z "$CONSUL_DEBUG" ]; then
     /usr/local/bin/envconsul -prefix $CONSUL_PREFIX -sanitize -upcase -once env


### PR DESCRIPTION
Added checks to prevent race conditions that will fail clustering. The following use cases have been addressed and tested.

- Check that Consul service is reachable: Targeting node startup to ensure the Consul agent is online and connected prior to the Rabbit instance starting.
- Check that the targeted service is reporting nodes: Required to ensure valid values are returned in determining the clustering target node.
- Check for cluster leader: Check for and hold leader election. All nodes will block waiting for healthy nodes without this logic. As container start order cannot be guaranteed, a semaphore is used to establish a lock on the instance that will be the clustering target for the other nodes.